### PR TITLE
Update TLS Certificate HEX instructions for LND

### DIFF
--- a/wallets/getting-started-alby-hub-en.html
+++ b/wallets/getting-started-alby-hub-en.html
@@ -73,14 +73,16 @@ make install
 </code></pre>
 <p>Once the LND is up and running, continue with <a href="https://docs.lightning.engineering/lightning-network-tools/lnd/macaroons">backing the macaroons</a> and TLS certificate required to connect Alby Hub, those will be necessary in this next step:</p>
 <p><img src="/assets/images/albyhub-LND.jpg" class="center"></p>
-<p>Go to /home/user/.lnd/ and open as text file the tls.cert. Copy the HEX code between "begin cerificate and end certificate. Paste it into Alby Hub - "TLS certificate HEX box."</p>
 <p>open Terminal and type:</p>
 
+<pre><code>xxd -ps -u -c 1000 /home/user/.lnd/tls.cert</code></pre>
+<p>You will obtain a HEX code for your TLS certificate and paste it into the Alby Hub - "TLS Certificate box".</p>  
+
 <pre><code>xxd -ps -u -c 1000 /path/to.macaroon</code></pre>
-<p>You will obtain a HEX code for your macarroon file and paste it into the Alby Hub - "Admin Macaroon box".</p>  
+<p>You will obtain a HEX code for your macaroon file and paste it into the Alby Hub - "Admin Macaroon box".</p>  
 <blockquote>
 <p style="color:Tomato;"><em>LND address - your local LND instance, eg. 127.0.0.1:10009</em></p>
-<p style="color:Tomato;"><em>TLS Certificate - copy the HEX from your tls.cert file</em></p>
+<p style="color:Tomato;"><em>TLS Certificate - convert in HEX your tls.cert file</em></p>
 <p style="color:Tomato;"><em>Admin Macaroon - convert in HEX your LND admin.macaroon</em></p>
 </blockquote>
 <h3>Cashu Mint backend</h3>

--- a/wallets/getting-started-alby-hub-es.html
+++ b/wallets/getting-started-alby-hub-es.html
@@ -258,11 +258,13 @@ make install
         necesarios en este siguiente paso:
       </p>
       <p><img src="/assets/images/albyhub-LND.jpg" class="center" /></p>
-      <p>Vaya a /home/user/.lnd/ y abra como archivo de texto el archivo tls.cert. Copie el código HEX entre "begin cerificate" y "end certificate". Péguelo en Alby Hub - "TLS certificate HEX box".</p>
 <p>Abra la Terminal y escriba:</p>
 
+<pre><code>xxd -ps -u -c 1000 /home/user/.lnd/tls.cert</code></pre>
+<p>Obtendrá un código HEX para su archivo certificado TLS y péguelo en Alby Hub - "TLS Certificate box".</p> 
+
 <pre><code>xxd -ps -u -c 1000 /path/to.macaroon</code></pre>
-<p>Obtendrá un código HEX para su archivo macarroon y péguelo en Alby Hub - "Admin Macaroon box".</p>
+<p>Obtendrá un código HEX para su archivo macaroon y péguelo en Alby Hub - "Admin Macaroon box".</p>
       <blockquote>
         <p style="color: Tomato">
           <em
@@ -272,7 +274,7 @@ make install
         </p>
         <p style="color: Tomato">
           <em
-            >Certificado TLS - Copia el HEX de tu archivo tls.cert</em
+            >Certificado TLS - Convierte tu archivo tls.cert en HEX</em
           >
         </p>
         <p style="color: Tomato">


### PR DESCRIPTION
Pasting the file contents between begin and end certificate of tls.cert was not working for me, but running xxd on tls.cert and pasting the hex output into the TLS Certificate box worked. Updated documentation to reflect these changes in instruction.